### PR TITLE
Refactor coordinate transformations for pieces

### DIFF
--- a/Blokus/DataTypes/Coordinate.swift
+++ b/Blokus/DataTypes/Coordinate.swift
@@ -7,6 +7,42 @@ struct Coordinate: Codable, Hashable, Equatable {
 }
 
 extension Coordinate {
+  /// 現在の座標を指定した回転量だけ回転させた座標を返します。
+  ///
+  /// - Parameter rotation: 適用する回転量
+  /// - Returns: 回転後の座標
+  func rotated(_ rotation: Rotation) -> Coordinate {
+    switch rotation {
+    case .none:
+      return self
+    case .ninety:
+      // (x, y) -> (y, -x)
+      return Coordinate(x: y, y: -x)
+    case .oneEighty:
+      // (x, y) -> (-x, -y)
+      return Coordinate(x: -x, y: -y)
+    case .twoSeventy:
+      // (x, y) -> (-y, x)
+      return Coordinate(x: -y, y: x)
+    }
+  }
+
+  /// 現在の座標を左右反転させた座標を返します。
+  ///
+  /// - Returns: 左右反転後の座標
+  func flippedHorizontally() -> Coordinate {
+    Coordinate(x: -x, y: y)
+  }
+
+  /// 現在の座標に指定した向きを適用した座標を返します。
+  ///
+  /// - Parameter orientation: 適用する向き情報
+  /// - Returns: 回転と反転を適用した座標
+  func applying(orientation: Orientation) -> Coordinate {
+    let rotatedCoordinate = rotated(orientation.rotation)
+    return orientation.flipped ? rotatedCoordinate.flippedHorizontally() : rotatedCoordinate
+  }
+
   /// 斜め方向の近傍セルを取得します。
   ///
   /// - Parameter coord: 基準となる座標

--- a/Blokus/DataTypes/Piece.swift
+++ b/Blokus/DataTypes/Piece.swift
@@ -12,29 +12,7 @@ struct Piece: Codable, Identifiable, Equatable {
 
 extension Piece {
   func transformedShape() -> [Coordinate] {
-    var transformed = baseShape
-    
-    // 回転適用
-    switch orientation.rotation {
-    case .none:
-      break
-    case .ninety:
-      // (x,y) -> (y, -x)
-      transformed = transformed.map { Coordinate(x: $0.y, y: -$0.x) }
-    case .oneEighty:
-      // (x,y) -> (-x, -y)
-      transformed = transformed.map { Coordinate(x: -$0.x, y: -$0.y) }
-    case .twoSeventy:
-      // (x,y) -> (-y, x)
-      transformed = transformed.map { Coordinate(x: -$0.y, y: $0.x) }
-    }
-    
-    // 反転適用 (水平反転とする)
-    if orientation.flipped {
-      transformed = transformed.map { Coordinate(x: -$0.x, y: $0.y) }
-    }
-    
-    return transformed
+    baseShape.map { $0.applying(orientation: orientation) }
   }
 }
 


### PR DESCRIPTION
## Summary
- add reusable helpers on Coordinate for applying rotation and horizontal flip
- simplify Piece.transformedShape by delegating to the new coordinate helpers

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68f2a3977bac83238ffb7e6dad2efe90