### PR TITLE
Fix piece rotation to affect only the selected piece

### DIFF
--- a/Blokus/Store.swift
+++ b/Blokus/Store.swift
@@ -68,27 +68,37 @@ import SwiftUI
   
   // MARK: - Piece Operations
   
-  /// 選択中の全てのコマを90度回転します。
+  /// 選択中のコマを90度回転します。
   /// 回転は `piece.orientation` を更新することで実現します。
   func rotatePiece() {
+    guard var selection = pieceSelection else { return }
+
     withAnimation(.default) {
-      pieces = pieces.map {
-        var piece = $0
-        piece.orientation.rotate90()
-        return piece
+      selection.orientation.rotate90()
+      pieceSelection = selection
+
+      if let index = pieces.firstIndex(where: { $0.id == selection.id }) {
+        pieces[index] = selection
       }
+
+      updateBoardHighlights()
     }
   }
-  
-  /// 選択中の全てのコマを反転します(上下反転)。
+
+  /// 選択中のコマを反転します(上下反転)。
   /// 反転は `piece.orientation.flip()` を利用して行われます。
   func flipPiece() {
+    guard var selection = pieceSelection else { return }
+
     withAnimation(.default) {
-      pieces = pieces.map {
-        var piece = $0
-        piece.orientation.flip()
-        return piece
+      selection.orientation.flip()
+      pieceSelection = selection
+
+      if let index = pieces.firstIndex(where: { $0.id == selection.id }) {
+        pieces[index] = selection
       }
+
+      updateBoardHighlights()
     }
   }
 

--- a/Blokus/Views/GameView.swift
+++ b/Blokus/Views/GameView.swift
@@ -40,9 +40,10 @@ struct GameView: View {
           Button {
             store.rotatePiece()
           } label: {
-            let flipped = store.pieces.first?.orientation.flipped ?? false
+            let flipped = store.pieceSelection?.orientation.flipped ?? false
             Label("Rotate", systemImage: flipped ? "rotate.right" : "rotate.left")
           }
+          .disabled(store.pieceSelection == nil)
           
           Button {
             isPresented = true
@@ -55,6 +56,7 @@ struct GameView: View {
           } label: {
             Label("Flip", systemImage: "trapezoid.and.line.vertical")
           }
+          .disabled(store.pieceSelection == nil)
         }
       }
       


### PR DESCRIPTION
## Summary
- limit piece rotation and flipping to the currently selected piece
- refresh board highlights after orientation changes
- disable transform controls when nothing is selected and drive the rotate icon from the selection state

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68f2a61b41bc8323b91ed698565c0f4a