### PR TITLE
Cache board player cells for faster placement checks

### DIFF
--- a/Blokus/Computers/Computer.swift
+++ b/Blokus/Computers/Computer.swift
@@ -28,15 +28,7 @@ extension Computer {
   
   /// ボードから指定プレイヤーのセルを取得します。
   func getPlayerCells(from board: Board, owner: Player) -> Set<Coordinate> {
-    var result = Set<Coordinate>()
-    for x in 0..<Board.width {
-      for y in 0..<Board.height {
-        if board.cells[x][y].owner == owner {
-          result.insert(Coordinate(x: x, y: y))
-        }
-      }
-    }
-    return result
+    return board.playerCellSet(for: owner)
   }
   
   /// 配置可能な全ての候補手を算出します。

--- a/BlokusTests/Computers/ComputerEasyTests.swift
+++ b/BlokusTests/Computers/ComputerEasyTests.swift
@@ -47,7 +47,7 @@ struct ComputerEasyTests {
     // 全てのセルをオーナーblueで埋める(占有状態)ことでredのコマが置けない状態を作る
     for x in 0..<Board.width {
       for y in 0..<Board.height {
-        board.cells[x][y] = Cell(owner: .blue)
+        board.setCell(owner: .blue, at: Coordinate(x: x, y: y))
       }
     }
     

--- a/BlokusTests/Computers/ComputerHardTests.swift
+++ b/BlokusTests/Computers/ComputerHardTests.swift
@@ -42,7 +42,7 @@ struct ComputerHardTests {
     // 全てのセルをオーナーblueで埋めてredが置けない状態にする
     for x in 0..<Board.width {
       for y in 0..<Board.height {
-        board.cells[x][y] = Cell(owner: .blue)
+        board.setCell(owner: .blue, at: Coordinate(x: x, y: y))
       }
     }
     

--- a/BlokusTests/Computers/ComputerNormalTests.swift
+++ b/BlokusTests/Computers/ComputerNormalTests.swift
@@ -109,7 +109,7 @@ struct ComputerNormalTests {
     // 全セルをfake占有
     for x in 0..<Board.width {
       for y in 0..<Board.height {
-        board.cells[y][x] = Cell(owner: .blue)
+        board.setCell(owner: .blue, at: Coordinate(x: x, y: y))
       }
     }
     


### PR DESCRIPTION
## Summary
- cache each player's occupied coordinates on the board and reuse them in placement validation
- provide a helper for setting cell ownership so caches stay in sync and restrict direct cell mutation
- switch computer helpers and tests to the cached data to avoid repeated full-board scans

## Testing
- swift test *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68f2a62a10908323afb4b92bf71e20ad