### PR TITLE
Add deterministic turn management

### DIFF
--- a/Blokus/DataTypes/PlayerColor.swift
+++ b/Blokus/DataTypes/PlayerColor.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 // プレイヤーの色
-enum Player: String, Codable, Equatable, CaseIterable {
+enum Player: String, Codable, Equatable, CaseIterable, Hashable {
   case red = "Red"
   case blue = "Blue"
   case green = "Green"

--- a/Blokus/DataTypes/TurnManager.swift
+++ b/Blokus/DataTypes/TurnManager.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// 手番の進行を管理するためのヘルパー。
+/// プレイヤーの順番を保持し、パス済みまたは全てのコマを使い切った
+/// プレイヤーを自動的にスキップします。
+struct TurnManager {
+  private let order: [Player]
+  private var currentIndex: Int?
+  private var inactivePlayers: Set<Player> = []
+
+  init(startingPlayer: Player = .red, order: [Player] = Player.allCases) {
+    self.order = order
+    if let index = order.firstIndex(of: startingPlayer) {
+      currentIndex = index
+    } else {
+      currentIndex = order.isEmpty ? nil : 0
+    }
+  }
+
+  var currentPlayer: Player? {
+    guard let index = currentIndex, order.indices.contains(index) else { return nil }
+    return order[index]
+  }
+
+  mutating func advance(after outcome: TurnOutcome) {
+    guard let current = currentPlayer else { return }
+
+    switch outcome {
+    case let .placed(player, hasRemainingPieces):
+      precondition(player == current, "Turn outcome must match the active player")
+      if hasRemainingPieces {
+        inactivePlayers.remove(player)
+      } else {
+        inactivePlayers.insert(player)
+      }
+
+    case let .passed(player):
+      precondition(player == current, "Turn outcome must match the active player")
+      inactivePlayers.insert(player)
+    }
+
+    currentIndex = nextActiveIndex(startingAfter: currentIndex)
+  }
+
+  private func nextActiveIndex(startingAfter index: Int?) -> Int? {
+    guard !order.isEmpty else { return nil }
+
+    let start = ((index ?? -1) + 1) % order.count
+    var candidateIndex = start
+
+    for _ in 0..<order.count {
+      let candidate = order[candidateIndex]
+      if !inactivePlayers.contains(candidate) {
+        return candidateIndex
+      }
+      candidateIndex = (candidateIndex + 1) % order.count
+    }
+
+    return nil
+  }
+}
+
+enum TurnOutcome {
+  case placed(player: Player, hasRemainingPieces: Bool)
+  case passed(player: Player)
+}

--- a/Blokus/Views/GameView.swift
+++ b/Blokus/Views/GameView.swift
@@ -22,19 +22,35 @@ struct GameView: View {
       }
       
       VStack(spacing: 12) {
-        Picker(selection: $store.player) {
-          ForEach(Player.allCases, id: \.color) { playerColor in
-            let point = store.board.score(for: playerColor)
-            let text = "\(playerColor.rawValue): \(point)pt"
-            Text(text)
-              .tag(playerColor)
+        VStack(alignment: .leading, spacing: 8) {
+          if store.isGameOver {
+            Text("Game Over")
+              .font(.headline)
+          } else {
+            Text("Current Player: \(store.player.rawValue)")
+              .font(.headline)
           }
-        } label: {
-          Text("label")
+
+          HStack(spacing: 12) {
+            ForEach(Player.allCases, id: \.rawValue) { playerColor in
+              let point = store.board.score(for: playerColor)
+              let text = "\(playerColor.rawValue): \(point)pt"
+              Text(text)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .background(
+                  Capsule()
+                    .fill(
+                      store.isGameOver
+                        ? Color.clear
+                        : (playerColor == store.player ? playerColor.color.opacity(0.2) : Color.clear)
+                    )
+                )
+            }
+          }
         }
-        .pickerStyle(.segmented)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 20)
-        .disabled(store.computerMode)
         
         HStack(spacing: 40) {
           Button {
@@ -86,6 +102,7 @@ struct GameView: View {
             .frame(maxWidth: .infinity)
         }
         .padding(.horizontal, 20)
+        .disabled(store.isGameOver)
       }
       .sensoryFeedback(.impact, trigger: store.pieceSelection)
       .sensoryFeedback(.impact, trigger: store.pieces)


### PR DESCRIPTION
## Summary
- add a dedicated `TurnManager` helper to keep track of the active player order and skip inactive colors
- update the store logic to advance turns, prevent manual color changes, and sequence computer moves per player
- refresh the game view to show the active player and game-over state instead of an editable picker

## Testing
- not run (iOS simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2a620f768832395300e8fa490837c