### PR TITLE
Fix board cell orientation consistency

### DIFF
--- a/Blokus/Board.swift
+++ b/Blokus/Board.swift
@@ -17,8 +17,8 @@ struct Board {
   /// 通常の Swift 配列では `cells[row][column]` と書くことが多いため、
   /// インデックスの並びを明確にする目的で列優先であることを明記しています。
   var cells: [[Cell]] = Array(
-    repeating: Array(repeating: Cell(owner: nil), count: Board.width),
-    count: Board.height
+    repeating: Array(repeating: Cell(owner: nil), count: Board.height),
+    count: Board.width
   )
   
   /// 配置可能な領域をハイライト表示するための座標集合

--- a/Blokus/Views/BoardView.swift
+++ b/Blokus/Views/BoardView.swift
@@ -8,12 +8,12 @@ struct BoardView: View {
   
   var body: some View {
     Grid(horizontalSpacing: 0, verticalSpacing: 0) {
-      ForEach(0..<Board.height, id: \.self) { column in
+      ForEach(0..<Board.height, id: \.self) { row in
         GridRow {
-          ForEach(0..<Board.width, id: \.self) { row in
-            let c = Coordinate(x: row, y: column)
+          ForEach(0..<Board.width, id: \.self) { column in
+            let c = Coordinate(x: column, y: row)
             let isHighlighted = board.highlightedCoordinates.contains(c)
-            let cell = board.cells[row][column]
+            let cell = board.cell(column: column, row: row)
             
             Group {
               if let owner = cell.owner {

--- a/BlokusTests/Computers/ComputerNormalTests.swift
+++ b/BlokusTests/Computers/ComputerNormalTests.swift
@@ -109,7 +109,7 @@ struct ComputerNormalTests {
     // 全セルをfake占有
     for x in 0..<Board.width {
       for y in 0..<Board.height {
-        board.cells[y][x] = Cell(owner: .blue)
+        board.cells[x][y] = Cell(owner: .blue)
       }
     }
     


### PR DESCRIPTION
## Summary
- initialize the board's cell grid using column-major dimensions to match the documented access pattern
- update `BoardView` to access cells via column/row helpers that respect the column-major layout
- align the `ComputerNormalTests` board-filling helper with the column-major indexing

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f2b0ca03d08323afc2586bca41bc72