### PR TITLE
Fix replay data access to respect actor isolation

### DIFF
--- a/Blokus/TurnRecorder.swift
+++ b/Blokus/TurnRecorder.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 actor TurnRecorder {
-  var turns: [Turn] = []
+  private var turns: [Turn] = []
 
   func currentIndexOf(owner: Player) -> Int {
     turns.filter { $0.owner == owner }.count
@@ -16,5 +16,9 @@ actor TurnRecorder {
   func recordPassAction(owner: Player) {
     let index = currentIndexOf(owner: owner)
     turns.append(Turn(index: index, action: .pass, owner: owner))
+  }
+
+  func recordedTurns() -> [Turn] {
+    turns
   }
 }

--- a/Blokus/Views/ReplayView.swift
+++ b/Blokus/Views/ReplayView.swift
@@ -22,7 +22,6 @@ final class ReplayStore: AnyObject {
 
   init(turns: [Turn]) {
     self.turns = turns
-      .sorted(by: { $0.index < $1.index })
   }
   
   func start() async {


### PR DESCRIPTION
## Summary
- add an accessor on TurnRecorder so callers can fetch recorded turns safely
- load the replay sheet with an asynchronously prepared ReplayStore instead of touching the actor state directly
- keep the replay turn order exactly as it was recorded instead of re-sorting by index

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68f2b0e009bc8323a43604de647763f7