### PR TITLE
Manage turn progression within Store

### DIFF
--- a/Blokus/Views/GameView.swift
+++ b/Blokus/Views/GameView.swift
@@ -22,7 +22,12 @@ struct GameView: View {
       }
       
       VStack(spacing: 12) {
-        Picker(selection: $store.player) {
+        Picker(
+          selection: Binding(
+            get: { store.player },
+            set: { _ in }
+          )
+        ) {
           ForEach(Player.allCases, id: \.color) { playerColor in
             let point = store.board.score(for: playerColor)
             let text = "\(playerColor.rawValue): \(point)pt"
@@ -34,7 +39,7 @@ struct GameView: View {
         }
         .pickerStyle(.segmented)
         .padding(.horizontal, 20)
-        .disabled(store.computerMode)
+        .allowsHitTesting(false)
         
         HStack(spacing: 40) {
           Button {


### PR DESCRIPTION
## Summary
- add turn order bookkeeping to the Store and expose an async `advanceTurn` method
- run computer turns through the store while resetting highlights when the player changes
- render the player picker as read-only so UI no longer mutates the active player directly

## Testing
- not run (iOS app project)


------
https://chatgpt.com/codex/tasks/task_e_68f2b0d2464c832394752a970663f7f8